### PR TITLE
fix: id mistake.

### DIFF
--- a/Radar/Radar.cs
+++ b/Radar/Radar.cs
@@ -428,7 +428,7 @@ public class Radar : IDisposable
                 fgColor = 4294967040u;
                 return true;
             }
-            if (NotoriousMonsters.ListFateMobs.Contains(objCharacter.NameId))
+            if (NotoriousMonsters.ListFateMobs.Contains(obj.DataId))
             {
                 SpecialObjectDrawList.Add((obj, 4294902015U, $"F.A.T.E NOTORIOUS MONSTER\nLv.{objCharacter.Level} {dictionaryName}"));
                 fgColor = 4294902015U;


### PR DESCRIPTION
After testing, it's confirmed this isn't the NPC name id but data id.

I suspect Eureka mobs might also data id, though I haven't played Eureka recently to verify.